### PR TITLE
Hello.

### DIFF
--- a/generator/virtuals.lua
+++ b/generator/virtuals.lua
@@ -105,9 +105,12 @@ function virtual_overload(v)
       } else
         lua_error(L);
     }
+  } else {
+    lua_settop(L, oldtop);
+    ]]..fallback..[[
   }
-  lua_settop(L, oldtop);
-  ]] .. fallback .. '\n}\n'
+}
+]]
 	v.virtual_overload = ret
 	v.virtual_proto = string.gsub(proto, ';;', '', 1)
 	return v


### PR DESCRIPTION
Consider the following:

```
local edit = QTextEdit.new_local()
function edit:keyPressEvent(e)
    -- do something
    error(SUPER)
end
```

This causes the base class QTextEdit::keyPressEvent(e) to be called twice since
the generated virtual method has the following form:

```
void lqt_shell_QTextEdit::keyPressEvent (QKeyEvent* arg1) {
  // ...
  if (lua_isfunction(L, -1)) {
    // ...
    if (!lqtL_pcall(L, 2, 0, 0)) {
      // ...
    } else {
      if (lqtL_is_super(L, lua_gettop(L))) {
        // ...
        this->QTextEdit::keyPressEvent(arg1);
      } else
         lua_error(L);
    }
  }
  // ...
  this->QTextEdit::keyPressEvent(arg1);
}
```
